### PR TITLE
remove redundant -L statements

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2343,7 +2343,7 @@ CheckPSPSDK()
 
     # Compile SDL with -G0 to disable the $gp register.
     EXTRA_CFLAGS="$EXTRA_CFLAGS -G0 -I\"${pspsdk_path}/include\""
-    EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L${pspsdk_path}/lib -L${psp_prefix} -lpspdebug -lpspgu -lpspctrl"
+    EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lpspdebug -lpspgu -lpspctrl"
     EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lpspge -lpspdisplay -lpsphprm -lpspsdk -lpsprtc"
     EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lpspaudio -lpsputility -lpspnet_inet"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the redundant -L statements because those are included by default by gcc, according to @sharkwouter. Thanks!

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
